### PR TITLE
feat: complete license system with UI panel and GitHub validation

### DIFF
--- a/oxware/backend/license_manager.py
+++ b/oxware/backend/license_manager.py
@@ -13,48 +13,62 @@ from pathlib import Path
 
 log = logging.getLogger("oxware.license")
 
-LICENSE_FILE = "/var/lib/oxware/license.json"
-LICENSE_REPO = "ShinnAsukha/oxware-license"
-LICENSE_FILE_PATH = ".licensecodes"
-# Bu key license repo'sundaki .licensecodes dosyasını şifrelemek için kullanılır.
-# Ayrı bir araçla üretilmiş Fernet anahtarı (base64 URL-safe):
-_FERNET_KEY = b"YWRhb3N3YXJlbGljZW5zZWtleS0zMmJ5dGVzLTIwMjQ="  # placeholder - gerçek projede değiştirilecek
+LICENSE_FILE    = "/var/lib/oxware/license.json"
+LICENSE_REPO    = "ShinnAsukha/oxware-license"
+LICENSE_RAW_URL = f"https://raw.githubusercontent.com/{LICENSE_REPO}/main/.licensecodes"
 
-_license_cache = None
-_cache_ts = 0
+# Şifreleme anahtarı — paroladan SHA-256 ile türetilmiş, Fernet için base64
+_PASSPHRASE = b"OXware-License-Secret-2024-ShinnAsukha"
+
+_codes_cache: list = []
+_cache_ts: float = 0.0
 CACHE_TTL = 3600  # 1 saat
 
 def _get_fernet():
     try:
         from cryptography.fernet import Fernet
         import base64
-        # 32 byte key oluştur
-        raw = b"oxware-license-secret-key-2024!!"  # 32 bytes
-        key = base64.urlsafe_b64encode(raw)
+        key_bytes = hashlib.sha256(_PASSPHRASE).digest()  # 32 bytes
+        key = base64.urlsafe_b64encode(key_bytes)
         return Fernet(key)
     except Exception as e:
         log.warning("Fernet yüklenemedi: %s", e)
         return None
 
 def _fetch_license_codes() -> list:
-    """GitHub'dan şifreli lisans dosyasını çek, çöz, kodları döndür."""
+    """GitHub'dan şifreli .licensecodes dosyasını çek, Fernet ile çöz."""
+    global _codes_cache, _cache_ts
+
+    # Cache geçerliyse tekrar çekme
+    if _codes_cache and (time.time() - _cache_ts) < CACHE_TTL:
+        return _codes_cache
+
     try:
         import urllib.request
-        url = f"https://raw.githubusercontent.com/{LICENSE_REPO}/main/{LICENSE_FILE_PATH}"
-        req = urllib.request.Request(url, headers={"User-Agent": "OXware/2.0"})
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            encrypted_data = resp.read()
+        req = urllib.request.Request(
+            LICENSE_RAW_URL,
+            headers={"User-Agent": "OXware/2.1", "Cache-Control": "no-cache"}
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            encrypted_data = resp.read().strip()
 
-        f = _get_fernet()
-        if not f:
+        fernet = _get_fernet()
+        if not fernet:
+            log.error("Fernet başlatılamadı")
             return []
 
-        decrypted = f.decrypt(encrypted_data)
-        codes = [line.strip() for line in decrypted.decode("utf-8").splitlines() if line.strip()]
+        decrypted = fernet.decrypt(encrypted_data)
+        codes = [line.strip() for line in decrypted.decode("utf-8").splitlines()
+                 if line.strip() and line.strip().startswith("OXWARE-")]
+
+        _codes_cache = codes
+        _cache_ts = time.time()
+        log.info("Lisans listesi güncellendi: %d kod", len(codes))
         return codes
+
     except Exception as e:
-        log.warning("Lisans dosyası alınamadı: %s", e)
-        return []
+        log.warning("Lisans dosyası alınamadı (%s): %s", LICENSE_RAW_URL, e)
+        return _codes_cache  # cache varsa eski listeyi döndür
 
 def validate_license(code: str) -> dict:
     """Lisans kodunu doğrula."""

--- a/oxware/frontend/templates/index.html
+++ b/oxware/frontend/templates/index.html
@@ -1335,6 +1335,39 @@
         <!-- ─────── tab-security ─────── -->
         <div class="page" id="page-tab-security">
           <div class="section-header"><h2><i class="fa-solid fa-user-shield" style="margin-right:8px;color:var(--accent-lt)"></i>Güvenlik</h2></div>
+
+          <!-- License Card -->
+          <div class="card" style="margin-bottom:14px;border:1px solid rgba(42,109,217,.25)">
+            <div class="card-title" style="display:flex;align-items:center;gap:10px">
+              <i class="fa-solid fa-key" style="color:var(--accent-lt)"></i>
+              <span id="lic-card-title">OXware Lisans</span>
+              <span id="lic-badge" style="display:none;margin-left:auto;padding:2px 10px;border-radius:20px;font-size:11px;font-weight:600;background:rgba(34,197,94,.15);color:#22c55e;border:1px solid rgba(34,197,94,.3)">
+                <i class="fa-solid fa-circle-check"></i> AKTİF
+              </span>
+              <span id="lic-badge-inactive" style="margin-left:auto;padding:2px 10px;border-radius:20px;font-size:11px;font-weight:600;background:rgba(239,68,68,.12);color:#ef4444;border:1px solid rgba(239,68,68,.3)">
+                <i class="fa-solid fa-circle-xmark"></i> AKTİF DEĞİL
+              </span>
+            </div>
+            <div id="lic-active-info" style="display:none;margin-bottom:12px;padding:10px 14px;background:rgba(34,197,94,.07);border:1px solid rgba(34,197,94,.2);border-radius:8px;font-size:12px">
+              <div style="color:#22c55e;font-weight:600;margin-bottom:4px"><i class="fa-solid fa-shield-check"></i> Lisans Aktif</div>
+              <div style="color:var(--text-muted)">Kod Öneki: <span id="lic-prefix" style="color:var(--text-primary);font-family:monospace"></span></div>
+              <div style="color:var(--text-muted)">Aktivasyon: <span id="lic-activated-at" style="color:var(--text-primary)"></span></div>
+            </div>
+            <div id="lic-input-row" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
+              <div class="form-group" style="flex:1;min-width:220px;margin:0">
+                <label style="font-size:11px;margin-bottom:4px;display:block;color:var(--text-muted)">Lisans Kodu</label>
+                <input id="lic-code-input" type="text" class="form-control" placeholder="OXWARE-XXXX-XXXX-XXXX-XXXX" style="font-family:monospace;letter-spacing:.5px" maxlength="29">
+              </div>
+              <button class="btn-primary" onclick="validateLicense()" style="white-space:nowrap"><i class="fa-solid fa-circle-check"></i> Doğrula</button>
+            </div>
+            <div id="lic-deactivate-row" style="display:none;margin-top:10px">
+              <button class="btn" onclick="deactivateLicense()" style="color:#ef4444;border-color:rgba(239,68,68,.4);font-size:12px">
+                <i class="fa-solid fa-circle-xmark"></i> Lisansı Deaktive Et
+              </button>
+            </div>
+            <div id="lic-msg" style="margin-top:10px;font-size:12px;display:none"></div>
+          </div>
+
           <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-bottom:14px">
             <div class="card">
               <div class="card-title">2FA Yönetimi</div>
@@ -2114,6 +2147,77 @@ async function checkLicenseStatus() {
     const d = await r.json();
     const banner = document.getElementById('license-banner');
     if (banner) banner.style.display = d.active ? 'flex' : 'none';
+    _applyLicenseUI(d);
+  } catch {}
+}
+
+function _applyLicenseUI(d) {
+  const badge        = document.getElementById('lic-badge');
+  const badgeInact   = document.getElementById('lic-badge-inactive');
+  const activeInfo   = document.getElementById('lic-active-info');
+  const inputRow     = document.getElementById('lic-input-row');
+  const deactRow     = document.getElementById('lic-deactivate-row');
+  if (!badge) return;
+  if (d.active) {
+    badge.style.display      = 'inline-flex';
+    badgeInact.style.display = 'none';
+    activeInfo.style.display = 'block';
+    inputRow.style.display   = 'none';
+    deactRow.style.display   = 'block';
+    const pfx = document.getElementById('lic-prefix');
+    const aat = document.getElementById('lic-activated-at');
+    if (pfx) pfx.textContent = d.code_prefix || '';
+    if (aat) aat.textContent = d.activated_at || '';
+  } else {
+    badge.style.display      = 'none';
+    badgeInact.style.display = 'inline-flex';
+    activeInfo.style.display = 'none';
+    inputRow.style.display   = 'flex';
+    deactRow.style.display   = 'none';
+  }
+}
+
+async function validateLicense() {
+  const input = document.getElementById('lic-code-input');
+  const msg   = document.getElementById('lic-msg');
+  const code  = (input ? input.value : '').trim().toUpperCase();
+  if (!code) return toast('Lütfen lisans kodunu girin', 'error');
+  msg.style.display = 'none';
+  try {
+    const r = await fetch('/api/license/validate', {
+      method: 'POST',
+      headers: {'Authorization':'Bearer '+TOKEN(), 'Content-Type':'application/json'},
+      body: JSON.stringify({code})
+    });
+    const d = await r.json();
+    if (d.valid) {
+      msg.style.cssText = 'display:block;color:#22c55e';
+      msg.innerHTML = '<i class="fa-solid fa-circle-check"></i> ' + (d.message || 'Lisans başarıyla doğrulandı');
+      toast('Lisans aktif edildi!', 'success');
+      await checkLicenseStatus();
+    } else {
+      msg.style.cssText = 'display:block;color:#ef4444';
+      msg.innerHTML = '<i class="fa-solid fa-circle-xmark"></i> ' + (d.error || 'Geçersiz lisans kodu');
+      toast(d.error || 'Geçersiz lisans kodu', 'error');
+    }
+  } catch(e) {
+    msg.style.cssText = 'display:block;color:#ef4444';
+    msg.innerHTML = '<i class="fa-solid fa-circle-xmark"></i> Bağlantı hatası';
+  }
+}
+
+async function deactivateLicense() {
+  if (!confirm('Lisansı deaktive etmek istediğinize emin misiniz?')) return;
+  try {
+    const r = await fetch('/api/license/deactivate', {
+      method: 'POST',
+      headers: {'Authorization':'Bearer '+TOKEN()}
+    });
+    const d = await r.json();
+    if (d.success) {
+      toast('Lisans deaktive edildi', 'info');
+      await checkLicenseStatus();
+    }
   } catch {}
 }
 
@@ -3633,7 +3737,7 @@ async function loadTabData(tabId) {
     case 'tab-proxy':        loadNginxSites(); break;
     case 'tab-monitoring':   loadPerfHistory('1h'); loadSmartData(); loadUptimes(); loadIdsStatus(); break;
     case 'tab-ai':           loadAiRecommendations(); loadAnomalies(); loadAIAgents(); break;
-    case 'tab-security':     load2faStatus(); loadAuditLog(); loadApiKeys(); loadLdapConfig(); break;
+    case 'tab-security':     load2faStatus(); loadAuditLog(); loadApiKeys(); loadLdapConfig(); checkLicenseStatus(); break;
     case 'tab-integrations': loadWebhooks(); loadS3Config(); loadEmailConfig(); loadVlans(); break;
     case 'tab-settings':     loadSdnStatus(); loadSslStatus(); loadScalerPolicies(); loadQuotas(); break;
   }


### PR DESCRIPTION
- license_manager.py: Fernet key from SHA-256 passphrase, fetches encrypted codes from ShinnAsukha/oxware-license repo, 1h cache
- index.html: license card on Security page (validate/deactivate), badge, active info display; validateLicense(), deactivateLicense(), _applyLicenseUI()
- checkLicenseStatus() now updates both banner and security page UI
- security tab load now also refreshes license status