### PR TITLE
feat(v2.8.0): real CSI/Firecracker/GitOps backends, pane cleanup, ver…

### DIFF
--- a/oxware/backend/app.py
+++ b/oxware/backend/app.py
@@ -843,7 +843,7 @@ if _v28 is not None:
             _fed = _safe_import("cluster_federation")
             _flags = _safe_import("feature_registry")
             return {
-                "oxware_version": "2.8.0-rc1",
+                "oxware_version": "2.8.0",
                 "vm_count": len((_vm.list_vms() if _vm else []) or []),
                 "node_count": len((_fed.list_members() if _fed else []) or []),
                 "enabled_features": [
@@ -851,7 +851,7 @@ if _v28 is not None:
                 ] if _flags and hasattr(_flags, "list_enabled") else [],
             }
         except Exception:
-            return {"oxware_version": "2.8.0-rc1"}
+            return {"oxware_version": "2.8.0"}
 
     if _telemetry is not None:
         try:
@@ -4648,7 +4648,7 @@ def api_system_info():
     return ok(
         host=system_monitor.get_host_info(),
         libvirt=system_monitor.get_libvirt_version(),
-        oxware_version="2.8.0-rc1",
+        oxware_version="2.8.0",
     )
 
 @app.route("/api/system/stats")
@@ -10225,7 +10225,7 @@ def api_openapi_spec():
         "openapi": "3.0.3",
         "info": {
             "title": "OXware Hypervisor API",
-            "version": "2.8.0-rc1",
+            "version": "2.8.0",
             "description": "KVM tabanlı hypervisor yönetim API'si"
         },
         "servers": [{"url": "/api", "description": "OXware API"}],
@@ -11691,7 +11691,7 @@ def api_provision_ping():
     else:
         panel = "Billing Panel"
     ev.info(f"Provisioning: {panel} baglantisi dogrulandi — IP: {client_ip}", category="provision")
-    return ok(status="ok", panel=panel, version="2.8.0-rc1", connected=True)
+    return ok(status="ok", panel=panel, version="2.8.0", connected=True)
 
 
 @app.route("/api/provision/create", methods=["POST"])

--- a/oxware/backend/csi_driver.py
+++ b/oxware/backend/csi_driver.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import shutil
+import subprocess
 import threading
 import time
 import uuid
@@ -20,6 +23,23 @@ log = logging.getLogger("oxware.csi")
 _CATALOG = Path("/var/lib/oxware/csi_volumes.json")
 _LOCK = threading.Lock()
 CSI_DRIVER_NAME = "csi.oxware.top"
+
+# Where qcow2 backing files live. Each pool maps to a sub-directory; if a
+# real libvirt pool path is configured the operator can symlink it here.
+_VOL_ROOT = Path("/var/lib/oxware/csi-volumes")
+_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]{1,200}$")
+
+
+def _qemu_img() -> str | None:
+    """Return the qemu-img binary path if present, else None."""
+    return shutil.which("qemu-img")
+
+
+def _vol_path(vol_id: str, pool: str) -> Path:
+    # Both segments validated so the joined path cannot escape _VOL_ROOT.
+    if not _NAME_RE.match(vol_id) or not _NAME_RE.match(pool):
+        raise ValueError("invalid pool or volume id")
+    return _VOL_ROOT / pool / f"{vol_id}.qcow2"
 
 
 def _load() -> dict:
@@ -48,8 +68,11 @@ def provision(pool: str, size_gb: int, k8s_namespace: str,
         return {"ok": False, "error": "size_gb must be >= 1"}
     if fs_type not in ("ext4", "xfs", "btrfs"):
         return {"ok": False, "error": f"unsupported fs_type: {fs_type}"}
+    if not _NAME_RE.match(pool):
+        return {"ok": False, "error": "invalid pool name"}
+    vol_id = f"pvc-{uuid.uuid4()}"
     vol = {
-        "id": f"pvc-{uuid.uuid4()}",
+        "id": vol_id,
         "pool": pool,
         "size_gb": int(size_gb),
         "k8s_namespace": k8s_namespace,
@@ -57,22 +80,59 @@ def provision(pool: str, size_gb: int, k8s_namespace: str,
         "fs_type": fs_type,
         "state": "pending",
         "created_at": time.time(),
+        "path": None,
+        "backend": "none",
     }
+    # Real backing: create a sparse qcow2 with qemu-img when available.
+    qemu = _qemu_img()
+    if qemu:
+        try:
+            path = _vol_path(vol_id, pool)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            r = subprocess.run(
+                [qemu, "create", "-f", "qcow2", str(path), f"{int(size_gb)}G"],
+                capture_output=True, text=True, timeout=60,
+            )
+            if r.returncode == 0:
+                vol["state"] = "available"
+                vol["path"] = str(path)
+                vol["backend"] = "qcow2"
+            else:
+                vol["state"] = "error"
+                vol["error"] = (r.stderr or r.stdout or "qemu-img failed")[:300]
+        except Exception as e:
+            vol["state"] = "error"
+            vol["error"] = str(e)[:300]
+    else:
+        # No qemu-img on this host — record intent, sidecar provisions later.
+        vol["state"] = "pending"
+        vol["note"] = "qemu-img not found; volume recorded, awaiting CSI sidecar"
     with _LOCK:
         d = _load()
         d["volumes"].append(vol)
         _save(d)
-    log.info("CSI provision queued: %s (%dGB, %s)", vol["id"], size_gb, pool)
-    return {"ok": True, "volume": vol}
+    log.info("CSI provision: %s (%dGB, %s, backend=%s, state=%s)",
+             vol_id, size_gb, pool, vol["backend"], vol["state"])
+    return {"ok": vol["state"] != "error", "volume": vol}
 
 
 def delete(volume_id: str) -> dict:
     with _LOCK:
         d = _load()
-        new = [v for v in d["volumes"] if v["id"] != volume_id]
-        if len(new) == len(d["volumes"]):
+        target = next((v for v in d["volumes"] if v["id"] == volume_id), None)
+        if not target:
             return {"ok": False, "error": "not found"}
-        d["volumes"] = new
+        # Remove the backing qcow2 if we created one.
+        p = target.get("path")
+        if p:
+            try:
+                fp = Path(p)
+                # Confirm the file is inside _VOL_ROOT before unlinking.
+                if str(fp.resolve()).startswith(str(_VOL_ROOT.resolve())) and fp.exists():
+                    fp.unlink()
+            except Exception as e:
+                log.warning("CSI delete: could not remove %s: %s", p, e)
+        d["volumes"] = [v for v in d["volumes"] if v["id"] != volume_id]
         _save(d)
     return {"ok": True, "volume_id": volume_id}
 
@@ -84,14 +144,30 @@ def resize(volume_id: str, new_size_gb: int) -> dict:
             if v["id"] == volume_id:
                 if new_size_gb <= v["size_gb"]:
                     return {"ok": False, "error": "online shrink not supported"}
+                # Grow the backing qcow2 with qemu-img resize when present.
+                qemu = _qemu_img()
+                if qemu and v.get("path"):
+                    try:
+                        r = subprocess.run(
+                            [qemu, "resize", v["path"], f"{int(new_size_gb)}G"],
+                            capture_output=True, text=True, timeout=60,
+                        )
+                        if r.returncode != 0:
+                            return {"ok": False,
+                                    "error": (r.stderr or "resize failed")[:300]}
+                        v["state"] = "available"
+                    except Exception as e:
+                        return {"ok": False, "error": str(e)[:300]}
+                else:
+                    v["state"] = "resizing"
                 v["size_gb"] = new_size_gb
-                v["state"] = "resizing"
                 _save(d)
                 return {"ok": True, "volume": v}
     return {"ok": False, "error": "not found"}
 
 
 def driver_info() -> dict:
+    qemu = _qemu_img()
     return {
         "name": CSI_DRIVER_NAME,
         "spec_version": "1.8.0",
@@ -102,4 +178,8 @@ def driver_info() -> dict:
             "PUBLISH_UNPUBLISH_VOLUME",
         ],
         "supported_fs": ["ext4", "xfs", "btrfs"],
+        "backend_ready": bool(qemu),
+        "qemu_img": qemu or "(not found)",
+        "volume_root": str(_VOL_ROOT),
+        "maturity": "beta",
     }

--- a/oxware/backend/firecracker_runtime.py
+++ b/oxware/backend/firecracker_runtime.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
+import signal
+import subprocess
 import threading
 import time
 import uuid
@@ -20,6 +23,22 @@ log = logging.getLogger("oxware.firecracker")
 _CATALOG = Path("/var/lib/oxware/firecracker_vms.json")
 _SOCKETS_DIR = Path("/run/oxware/firecracker")
 _LOCK = threading.Lock()
+
+
+def _firecracker_bin() -> str | None:
+    return shutil.which("firecracker")
+
+
+def runtime_status() -> dict:
+    """Report whether the firecracker binary + /dev/kvm are present so the
+    panel can show a clear 'ready / not installed' badge."""
+    fc = _firecracker_bin()
+    return {
+        "firecracker_bin": fc or "(not found)",
+        "kvm_available": os.path.exists("/dev/kvm"),
+        "ready": bool(fc) and os.path.exists("/dev/kvm"),
+        "maturity": "experimental",
+    }
 
 
 def _load() -> dict:
@@ -42,32 +61,99 @@ def list_microvms() -> list:
     return _load().get("vms", [])
 
 
+def _write_fc_config(vm: dict, cfg_path: Path) -> None:
+    """Write a Firecracker JSON machine config (boot-source + drives + machine)."""
+    cfg = {
+        "boot-source": {
+            "kernel_image_path": vm["kernel_path"],
+            "boot_args": "console=ttyS0 reboot=k panic=1 pci=off",
+        },
+        "drives": [{
+            "drive_id": "rootfs",
+            "path_on_host": vm["rootfs_path"],
+            "is_root_device": True,
+            "is_read_only": False,
+        }],
+        "machine-config": {
+            "vcpu_count": vm["vcpus"],
+            "mem_size_mib": vm["memory_mb"],
+            "smt": False,
+        },
+    }
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+
+
 def launch(name: str, kernel_path: str, rootfs_path: str,
            vcpus: int = 1, memory_mb: int = 128) -> dict:
-    """Register a Firecracker microVM. The actual jailer + firecracker
-    process is started by the OXware microvm-runner systemd unit."""
+    """Launch a Firecracker microVM. Spawns the real firecracker process
+    with a generated machine config when the binary + /dev/kvm exist;
+    otherwise records the intent for an out-of-band runner."""
     if vcpus < 1 or vcpus > 16:
         return {"ok": False, "error": "vcpus must be 1..16"}
     if memory_mb < 64 or memory_mb > 16384:
         return {"ok": False, "error": "memory_mb must be 64..16384"}
+    if not name or "/" in name or ".." in name:
+        return {"ok": False, "error": "invalid name"}
+    vm_id = f"fc-{uuid.uuid4().hex[:8]}"
+    sock = _SOCKETS_DIR / f"{name}.sock"
+    cfg_path = _SOCKETS_DIR / f"{name}.json"
     vm = {
-        "id": f"fc-{uuid.uuid4().hex[:8]}",
+        "id": vm_id,
         "name": name,
         "kernel_path": kernel_path,
         "rootfs_path": rootfs_path,
         "vcpus": vcpus,
         "memory_mb": memory_mb,
-        "api_socket": str(_SOCKETS_DIR / f"{name}.sock"),
+        "api_socket": str(sock),
+        "config_path": str(cfg_path),
+        "pid": None,
         "state": "pending",
         "created_at": time.time(),
     }
+    fc = _firecracker_bin()
+    kvm = os.path.exists("/dev/kvm")
+    if fc and kvm:
+        # Validate the kernel + rootfs exist before spending a process slot.
+        if not Path(kernel_path).exists():
+            vm["state"] = "error"
+            vm["error"] = f"kernel not found: {kernel_path}"
+        elif not Path(rootfs_path).exists():
+            vm["state"] = "error"
+            vm["error"] = f"rootfs not found: {rootfs_path}"
+        else:
+            try:
+                _SOCKETS_DIR.mkdir(parents=True, exist_ok=True)
+                if sock.exists():
+                    sock.unlink()
+                _write_fc_config(vm, cfg_path)
+                proc = subprocess.Popen(
+                    [fc, "--api-sock", str(sock), "--config-file", str(cfg_path)],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                # Give it a beat to crash on bad args.
+                time.sleep(0.2)
+                if proc.poll() is None:
+                    vm["state"] = "running"
+                    vm["pid"] = proc.pid
+                else:
+                    vm["state"] = "error"
+                    vm["error"] = f"firecracker exited rc={proc.returncode}"
+            except Exception as e:
+                vm["state"] = "error"
+                vm["error"] = str(e)[:300]
+    else:
+        vm["state"] = "pending"
+        vm["note"] = ("firecracker binary or /dev/kvm missing; "
+                      "intent recorded for out-of-band runner")
     with _LOCK:
         d = _load()
         d["vms"].append(vm)
         _save(d)
-    log.info("firecracker microVM queued: %s (%d vcpus, %dMB)",
-             name, vcpus, memory_mb)
-    return {"ok": True, "vm": vm}
+    log.info("firecracker launch: %s (%d vcpus, %dMB, state=%s)",
+             name, vcpus, memory_mb, vm["state"])
+    return {"ok": vm["state"] != "error", "vm": vm}
 
 
 def stop(vm_id: str) -> dict:
@@ -75,7 +161,24 @@ def stop(vm_id: str) -> dict:
         d = _load()
         for vm in d["vms"]:
             if vm["id"] == vm_id:
+                pid = vm.get("pid")
+                if pid:
+                    try:
+                        os.kill(int(pid), signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                    except Exception as e:
+                        log.warning("fc stop: kill %s failed: %s", pid, e)
+                sock = vm.get("api_socket")
+                if sock:
+                    try:
+                        sp = Path(sock)
+                        if sp.exists():
+                            sp.unlink()
+                    except Exception:
+                        pass
                 vm["state"] = "stopped"
+                vm["pid"] = None
                 _save(d)
                 return {"ok": True, "vm_id": vm_id, "state": "stopped"}
     return {"ok": False, "error": "not found"}

--- a/oxware/backend/gitops_manager.py
+++ b/oxware/backend/gitops_manager.py
@@ -12,13 +12,80 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+import shutil
+import subprocess
 import threading
 import time
 from pathlib import Path
 
 log = logging.getLogger("oxware.gitops")
 _CATALOG = Path("/var/lib/oxware/gitops_repos.json")
+_CHECKOUT_ROOT = Path("/var/lib/oxware/gitops-checkouts")
 _LOCK = threading.Lock()
+_NAME_RE = re.compile(r"^[a-zA-Z0-9._-]{1,100}$")
+
+
+def _git_bin() -> str | None:
+    return shutil.which("git")
+
+
+def _checkout_dir(name: str) -> Path:
+    if not _NAME_RE.match(name):
+        raise ValueError("invalid repo name")
+    return _CHECKOUT_ROOT / name
+
+
+def _do_git_sync(repo: dict) -> dict:
+    """Clone or pull the repo, then scan vms/ + networks/ manifest dirs.
+    Returns a dict with file counts + any error. Real work, guarded on the
+    git binary being present."""
+    git = _git_bin()
+    if not git:
+        return {"ok": False, "error": "git binary not found on host"}
+    name = repo["id"]
+    url = repo["url"]
+    branch = repo.get("branch", "main")
+    token = repo.get("auth_token") or ""
+    # Inject token into https URL if provided (never logged).
+    clone_url = url
+    if token and url.startswith("https://"):
+        clone_url = url.replace("https://", f"https://{token}@", 1)
+    dest = _checkout_dir(name)
+    try:
+        if (dest / ".git").exists():
+            cmd = [git, "-C", str(dest), "pull", "--ff-only", "origin", branch]
+        else:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            if dest.exists():
+                shutil.rmtree(str(dest), ignore_errors=True)
+            cmd = [git, "clone", "--depth", "1", "--branch", branch,
+                   clone_url, str(dest)]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if r.returncode != 0:
+            # Scrub token from any error text before returning.
+            err = (r.stderr or r.stdout or "git failed")[:400]
+            if token:
+                err = err.replace(token, "***")
+            return {"ok": False, "error": err}
+    except Exception as e:
+        msg = str(e)
+        if token:
+            msg = msg.replace(token, "***")
+        return {"ok": False, "error": msg[:400]}
+    # Scan manifest dirs.
+    vm_manifests = sorted(str(p.name) for p in (dest / "vms").glob("*.y*ml")) \
+        if (dest / "vms").is_dir() else []
+    net_manifests = sorted(str(p.name) for p in (dest / "networks").glob("*.y*ml")) \
+        if (dest / "networks").is_dir() else []
+    return {
+        "ok": True,
+        "vm_manifests": vm_manifests,
+        "network_manifests": net_manifests,
+        "vm_count": len(vm_manifests),
+        "network_count": len(net_manifests),
+        "checkout": str(dest),
+    }
 
 
 def _load() -> dict:
@@ -78,18 +145,38 @@ def remove_repo(name: str) -> dict:
             return {"ok": False, "error": "not found"}
         d["repos"] = new
         _save(d)
+    # Best-effort cleanup of the local checkout.
+    try:
+        cd = _checkout_dir(name)
+        if cd.exists():
+            shutil.rmtree(str(cd), ignore_errors=True)
+    except Exception as e:
+        log.warning("gitops remove: checkout cleanup failed: %s", e)
     return {"ok": True, "name": name}
 
 
 def sync_now(name: str) -> dict:
-    """Mark a repo as needing immediate sync. The actual git fetch is
-    performed by a background worker (not implemented in this stub)."""
+    """Clone/pull the repo and scan its manifest directories now."""
+    with _LOCK:
+        d = _load()
+        repo = next((r for r in d["repos"] if r["id"] == name), None)
+        if not repo:
+            return {"ok": False, "error": "not found"}
+    # Run git outside the lock (network I/O can be slow).
+    result = _do_git_sync(repo)
     with _LOCK:
         d = _load()
         for r in d["repos"]:
             if r["id"] == name:
-                r["state"] = "syncing"
                 r["last_sync"] = time.time()
+                if result.get("ok"):
+                    r["state"] = "synced"
+                    r["vm_count"] = result.get("vm_count", 0)
+                    r["network_count"] = result.get("network_count", 0)
+                    r["last_error"] = None
+                else:
+                    r["state"] = "error"
+                    r["last_error"] = result.get("error")
                 _save(d)
-                return {"ok": True, "repo": name, "state": "syncing"}
-    return {"ok": False, "error": "not found"}
+                break
+    return {"ok": result.get("ok", False), "repo": name, **result}

--- a/oxware/backend/sbom_generator.py
+++ b/oxware/backend/sbom_generator.py
@@ -71,9 +71,9 @@ def generate(out_path: str | Path = _OUT_PATH) -> dict:
             "component": {
                 "type": "application",
                 "name": "oxware-hypervisor",
-                "version": os.environ.get("OXWARE_VERSION", "2.7.2"),
+                "version": os.environ.get("OXWARE_VERSION", "2.8.0"),
                 "purl": "pkg:generic/oxware-hypervisor@"
-                + os.environ.get("OXWARE_VERSION", "2.7.2"),
+                + os.environ.get("OXWARE_VERSION", "2.8.0"),
             },
             "properties": [
                 {"name": "python_version", "value": platform.python_version()},

--- a/oxware/frontend/templates/index.html
+++ b/oxware/frontend/templates/index.html
@@ -744,6 +744,13 @@
     .dash-widget-label{display:none;position:absolute;top:4px;right:8px;font-size:9px;font-weight:700;color:var(--text-muted);text-transform:uppercase;letter-spacing:.08em;z-index:3}
     .dash-edit-mode .dash-widget-label{display:block}
 
+    /* Maturity badges for experimental / beta modules */
+    .mat-badge{display:inline-flex;align-items:center;gap:4px;font-size:9px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:2px 7px;border-radius:10px;margin-left:10px;vertical-align:middle}
+    .mat-badge.beta{background:rgba(0,184,230,.14);color:#00b8e6;border:1px solid rgba(0,184,230,.35)}
+    .mat-badge.exp{background:rgba(245,166,35,.14);color:#f5a623;border:1px solid rgba(245,166,35,.35)}
+    .mat-badge.ready{background:rgba(34,197,94,.14);color:#22c55e;border:1px solid rgba(34,197,94,.35)}
+    .mat-badge.notready{background:rgba(239,68,68,.12);color:#ef4444;border:1px solid rgba(239,68,68,.3)}
+
     /* Topology */
     #topo-canvas-wrap{position:relative;border:1px solid var(--border);border-radius:4px;background:var(--surface);overflow:hidden}
     #topo-svg{width:100%;height:100%;cursor:grab;display:block}
@@ -1323,7 +1330,7 @@
                 </div>
                 <div class="esxi-meta-row">
                   <span class="esxi-meta-key">Version</span>
-                  <span class="esxi-meta-val" id="ns-oxware-ver">2.7.2</span>
+                  <span class="esxi-meta-val" id="ns-oxware-ver">2.8.0</span>
                 </div>
                 <div class="esxi-meta-row">
                   <span class="esxi-meta-key">Kernel</span>
@@ -7378,7 +7385,7 @@
 
         <!-- ══ v2.7.2 — Kubernetes CSI ══ -->
         <div id="ent-pane-csi" style="display:none">
-          <div class="section-header"><h2><i class="fa-brands fa-docker fa-fw" style="color:#2496ed"></i> Kubernetes CSI</h2><div class="spacer"></div><button class="btn" onclick="loadCsiPage()" style="font-size:12px"><i class="fa-solid fa-rotate"></i> Yenile</button></div>
+          <div class="section-header"><h2><i class="fa-brands fa-docker fa-fw" style="color:#2496ed"></i> Kubernetes CSI <span class="mat-badge beta">Beta</span><span id="csi-ready-badge"></span></h2><div class="spacer"></div><button class="btn" onclick="loadCsiPage()" style="font-size:12px"><i class="fa-solid fa-rotate"></i> Yenile</button></div>
           <div class="card" style="margin-bottom:12px;border-left:4px solid #2496ed;background:rgba(36,150,237,.04);padding:14px"><div style="font-size:12px;line-height:1.6"><b style="color:#2496ed">Bu Nedir?</b> OXware depolama havuzlarını Kubernetes PersistentVolume olarak sunar. Provision / Snapshot / Resize tek API'den.</div></div>
           <div class="card" style="margin-bottom:12px"><div class="card-title">Sürücü Bilgisi</div><div id="csi-info" class="text-muted" style="font-size:12px">Yükleniyor...</div></div>
           <div class="card" style="margin-bottom:12px"><div class="card-title">Yeni Volume</div>
@@ -7391,51 +7398,6 @@
               <button class="btn-primary" onclick="csiProvision()" style="font-size:12px"><i class="fa-solid fa-plus"></i> Provision</button>
             </div></div>
           <div class="card"><div class="card-title">Volume'ler</div><div class="table-wrap"><table><thead><tr><th>ID</th><th>Havuz</th><th>Boyut</th><th>Namespace</th><th>PVC</th><th>FS</th><th>Durum</th><th>İşlem</th></tr></thead><tbody id="csi-vol-tbody"><tr><td colspan="8" class="text-center text-muted" style="padding:14px">Yükleniyor...</td></tr></tbody></table></div></div>
-        </div>
-
-        <!-- ══ v2.7.2 — KubeVirt Bridge ══ -->
-        <div id="ent-pane-kubevirt" style="display:none">
-          <div class="section-header"><h2><i class="fa-solid fa-cubes fa-fw" style="color:#326ce5"></i> KubeVirt Bridge</h2><div class="spacer"></div><button class="btn" onclick="loadKubeVirtPage()" style="font-size:12px"><i class="fa-solid fa-rotate"></i> Yenile</button></div>
-          <div class="card" style="margin-bottom:12px;border-left:4px solid #326ce5;background:rgba(50,108,229,.04);padding:14px"><div style="font-size:12px;line-height:1.6"><b style="color:#326ce5">Bu Nedir?</b> Kayıtlı Kubernetes cluster'larındaki KubeVirt VirtualMachine CR'lerini OXware'de VM olarak çalıştır.</div></div>
-          <div class="card" style="margin-bottom:12px"><div class="card-title">Cluster Kaydet</div>
-            <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Cluster Adı</label><input id="kv-name" class="form-control" style="width:160px;margin-top:4px"></div>
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Watch Namespace</label><input id="kv-ns" class="form-control" style="width:160px;margin-top:4px" placeholder="* (hepsi)"></div>
-              <div class="form-group" style="margin:0;flex:1;min-width:280px"><label style="font-size:11px">kubeconfig (base64)</label><textarea id="kv-cfg" class="form-control" style="width:100%;margin-top:4px;font-family:monospace;font-size:11px;height:60px"></textarea></div>
-              <button class="btn-primary" onclick="kvRegister()" style="font-size:12px"><i class="fa-solid fa-plus"></i> Kaydet</button>
-            </div></div>
-          <div class="card"><div class="card-title">Kayıtlı Cluster'lar</div><div class="table-wrap"><table><thead><tr><th>Adı</th><th>Namespace</th><th>Durum</th><th>Eklenme</th><th>İşlem</th></tr></thead><tbody id="kv-tbody"><tr><td colspan="5" class="text-center text-muted" style="padding:14px">Yükleniyor...</td></tr></tbody></table></div></div>
-        </div>
-
-        <!-- ══ v2.7.2 — GitOps ══ -->
-        <div id="ent-pane-gitops" style="display:none">
-          <div class="section-header"><h2><i class="fa-solid fa-code-branch fa-fw" style="color:#f1502f"></i> GitOps Manager</h2><div class="spacer"></div><button class="btn" onclick="loadGitOpsPage()" style="font-size:12px"><i class="fa-solid fa-rotate"></i> Yenile</button></div>
-          <div class="card" style="margin-bottom:12px;border-left:4px solid #f1502f;background:rgba(241,80,47,.04);padding:14px"><div style="font-size:12px;line-height:1.6"><b style="color:#f1502f">Bu Nedir?</b> ArgoCD/Flux dizin yapısıyla uyumlu git repo sync. <code>vms/&lt;name&gt;.yaml</code> + <code>networks/&lt;name&gt;.yaml</code> manifesto'ları izle, drift raporu üret.</div></div>
-          <div class="card" style="margin-bottom:12px"><div class="card-title">Repo Ekle</div>
-            <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Ad</label><input id="go-name" class="form-control" style="width:140px;margin-top:4px"></div>
-              <div class="form-group" style="margin:0;flex:1;min-width:280px"><label style="font-size:11px">URL</label><input id="go-url" class="form-control" style="width:100%;margin-top:4px" placeholder="https://github.com/org/repo.git"></div>
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Branch</label><input id="go-branch" class="form-control" style="width:100px;margin-top:4px" value="main"></div>
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Auto-apply</label><div style="margin-top:8px"><input id="go-auto" type="checkbox"></div></div>
-              <button class="btn-primary" onclick="goAddRepo()" style="font-size:12px"><i class="fa-solid fa-plus"></i> Ekle</button>
-            </div></div>
-          <div class="card"><div class="card-title">Repo'lar</div><div class="table-wrap"><table><thead><tr><th>Ad</th><th>URL</th><th>Branch</th><th>Auto</th><th>Son Sync</th><th>Drift</th><th>İşlem</th></tr></thead><tbody id="go-tbody"><tr><td colspan="7" class="text-center text-muted" style="padding:14px">Yükleniyor...</td></tr></tbody></table></div></div>
-        </div>
-
-        <!-- ══ v2.7.2 — Firecracker microVMs ══ -->
-        <div id="ent-pane-firecracker" style="display:none">
-          <div class="section-header"><h2><i class="fa-solid fa-fire fa-fw" style="color:#ff8000"></i> Firecracker microVMs</h2><div class="spacer"></div><button class="btn" onclick="loadFirecrackerPage()" style="font-size:12px"><i class="fa-solid fa-rotate"></i> Yenile</button></div>
-          <div class="card" style="margin-bottom:12px;border-left:4px solid #ff8000;background:rgba(255,128,0,.04);padding:14px"><div style="font-size:12px;line-height:1.6"><b style="color:#ff8000">Bu Nedir?</b> &lt;125 ms boot, &lt;5 MB overhead microVM ikinci-katman runtime. Serverless / CI runner / per-request VM.</div></div>
-          <div class="card" style="margin-bottom:12px"><div class="card-title">microVM Başlat</div>
-            <div style="display:flex;gap:8px;flex-wrap:wrap;align-items:flex-end">
-              <div class="form-group" style="margin:0"><label style="font-size:11px">Ad</label><input id="fc-name" class="form-control" style="width:140px;margin-top:4px"></div>
-              <div class="form-group" style="margin:0;flex:1;min-width:240px"><label style="font-size:11px">Kernel Yolu</label><input id="fc-kernel" class="form-control" style="width:100%;margin-top:4px" placeholder="/var/lib/oxware/vmlinux"></div>
-              <div class="form-group" style="margin:0;flex:1;min-width:240px"><label style="font-size:11px">RootFS Yolu</label><input id="fc-rootfs" class="form-control" style="width:100%;margin-top:4px" placeholder="/var/lib/oxware/rootfs.ext4"></div>
-              <div class="form-group" style="margin:0"><label style="font-size:11px">vCPU</label><input id="fc-vcpu" type="number" class="form-control" style="width:70px;margin-top:4px" value="1"></div>
-              <div class="form-group" style="margin:0"><label style="font-size:11px">RAM (MB)</label><input id="fc-mem" type="number" class="form-control" style="width:90px;margin-top:4px" value="128"></div>
-              <button class="btn-primary" onclick="fcLaunch()" style="font-size:12px"><i class="fa-solid fa-fire"></i> Başlat</button>
-            </div></div>
-          <div class="card"><div class="card-title">Aktif microVM'ler</div><div class="table-wrap"><table><thead><tr><th>ID</th><th>Ad</th><th>vCPU</th><th>RAM</th><th>Durum</th><th>Socket</th><th>İşlem</th></tr></thead><tbody id="fc-tbody"><tr><td colspan="7" class="text-center text-muted" style="padding:14px">Yükleniyor...</td></tr></tbody></table></div></div>
         </div>
 
         <!-- ══ v2.7.2 — OAuth2 Presets ══ -->
@@ -23256,7 +23218,7 @@ function buildContextNav(type) {
     <!-- Key facts -->
     <div style="display:flex;flex-direction:column;gap:3px;color:var(--text-muted);font-size:10px">
       <div style="display:flex;justify-content:space-between"><span>Host IP</span><span id="sb-host-ip" style="color:var(--text);font-family:monospace">—</span></div>
-      <div style="display:flex;justify-content:space-between"><span>Sürüm</span><span id="sb-version" style="color:var(--text)">2.7.2</span></div>
+      <div style="display:flex;justify-content:space-between"><span>Sürüm</span><span id="sb-version" style="color:var(--text)">2.8.0</span></div>
       <div style="display:flex;justify-content:space-between"><span>Uptime</span><span id="sb-uptime" style="color:var(--text)">—</span></div>
       <div style="display:flex;justify-content:space-between"><span>CPU</span><span id="sb-cpu-count" style="color:var(--text)">—</span></div>
       <div style="display:flex;justify-content:space-between"><span>KVM</span><span id="sb-kvm" style="color:#22c55e">—</span></div>
@@ -24111,11 +24073,11 @@ async function loadNodeSummary() {
 
     // System info
     document.getElementById("ns-cpuinfo").textContent = `${cpuCount} x ${infoData.host?.cpu_model || "—"}`;
-    document.getElementById("ns-kernel").textContent = `OXware-${infoData.oxware_version || "2.7.2"}-generic#${infoData.host?.distro || 'Linux'}`;
+    document.getElementById("ns-kernel").textContent = `OXware-${infoData.oxware_version || "2.8.0"}-generic#${infoData.host?.distro || 'Linux'}`;
     document.getElementById("ns-kvm").textContent = infoData.host?.kvm_available ? "Available " : "Not Available ";
     document.getElementById("ns-arch").textContent = infoData.host?.architecture || "—";
     document.getElementById("ns-iodelay").textContent = ((s.disk_io?.read_count || 0) > 0 ? "< 1%" : "0%");
-    document.getElementById("ns-hv").textContent = `OXware ${infoData.oxware_version || "2.7.2"}`;
+    document.getElementById("ns-hv").textContent = `OXware ${infoData.oxware_version || "2.8.0"}`;
 
     // Center panel: VM counts
     const _vmRun = vmSumData?.running ?? '—';
@@ -33998,11 +33960,9 @@ const ENT_LOADERS = {
   runbook:     () => { try { loadRunbookPage(); } catch(e) { console.warn(e); } },
   federation:  () => { try { loadFederationPage(); } catch(e) { console.warn(e); } },
   apidocs: () => { try { loadApiDocsPage(); } catch(e) { console.warn(e); } },
-  // v2.7.2 — Cloud-Native panes
+  // v2.7.2 — Cloud-Native panes (kubevirt/gitops/firecracker dispatch
+  // handled by the original entries above — do not re-add to avoid dup keys)
   csi:            () => { try { loadCsiPage(); } catch(e) { console.warn(e); } },
-  kubevirt:       () => { try { loadKubeVirtPage(); } catch(e) { console.warn(e); } },
-  gitops:         () => { try { loadGitOpsPage(); } catch(e) { console.warn(e); } },
-  firecracker:    () => { try { loadFirecrackerPage(); } catch(e) { console.warn(e); } },
   oauth2presets:  () => { try { loadOauth2PresetsPage(); } catch(e) { console.warn(e); } },
   auditretention: () => { try { loadAuditRetentionPage(); } catch(e) { console.warn(e); } },
   sbom:           () => { try { loadSbomPage(); } catch(e) { console.warn(e); } },
@@ -37324,6 +37284,10 @@ async function loadCsiPage() {
   const info = await _api('/api/v2/csi/info');
   const inf = document.getElementById('csi-info');
   if (inf) inf.innerHTML = info ? _entKV(info) : '<span class="text-muted">Veri yok</span>';
+  const rb = document.getElementById('csi-ready-badge');
+  if (rb) rb.outerHTML = info && info.backend_ready
+    ? '<span id="csi-ready-badge" class="mat-badge ready">qemu-img ready</span>'
+    : '<span id="csi-ready-badge" class="mat-badge notready">qemu-img yok</span>';
   const vols = await _api('/api/v2/csi/volumes');
   const arr = (vols && vols.volumes) || [];
   const tb = document.getElementById('csi-vol-tbody');
@@ -37346,80 +37310,11 @@ async function csiDelete(id) {
   if (d) { toast('Volume silindi','success'); loadCsiPage(); }
 }
 
-/* ──── KubeVirt Bridge ──── */
-async function loadKubeVirtPage() {
-  const d = await _api('/api/v2/kubevirt/clusters');
-  const arr = (d && d.clusters) || [];
-  const tb = document.getElementById('kv-tbody');
-  if (tb) tb.innerHTML = arr.length ? arr.map(c => `<tr><td><b>${_esc(c.name||'-')}</b></td><td>${_esc(c.watch_namespace||'*')}</td><td>${_esc(c.state||'-')}</td><td>${c.added_at?new Date(c.added_at*1000).toLocaleString():'-'}</td><td><button class="btn sm danger" onclick="kvDel('${_esc(c.name)}')"><i class="fa-solid fa-trash"></i></button></td></tr>`).join('') : '<tr><td colspan="5" class="text-center text-muted" style="padding:14px">Kayıtlı cluster yok</td></tr>';
-}
-async function kvRegister() {
-  const body = {
-    name: document.getElementById('kv-name').value.trim(),
-    kubeconfig_b64: document.getElementById('kv-cfg').value.trim(),
-    watch_namespace: document.getElementById('kv-ns').value.trim(),
-  };
-  if (!body.name || !body.kubeconfig_b64) { toast('Ad ve kubeconfig gerekli','error'); return; }
-  const d = await _api('/api/v2/kubevirt/clusters','POST',body);
-  if (d) { toast('Cluster kaydedildi','success'); loadKubeVirtPage(); }
-}
-async function kvDel(n) {
-  if (!await showConfirm(`${n} cluster kaydı silinecek. Devam?`,'Cluster Sil',true)) return;
-  const d = await _api(`/api/v2/kubevirt/clusters/${encodeURIComponent(n)}`,'DELETE');
-  if (d) { toast('Silindi','success'); loadKubeVirtPage(); }
-}
-
-/* ──── GitOps Manager ──── */
-async function loadGitOpsPage() {
-  const d = await _api('/api/v2/gitops/repos');
-  const arr = (d && d.repos) || [];
-  const tb = document.getElementById('go-tbody');
-  if (tb) tb.innerHTML = arr.length ? arr.map(r => `<tr><td><b>${_esc(r.name||'-')}</b></td><td style="font-family:monospace;font-size:10px">${_esc(r.url||'-')}</td><td>${_esc(r.branch||'main')}</td><td>${r.auto_apply?'<span style="color:#3fb950">✓</span>':'<span class="text-muted">-</span>'}</td><td>${r.last_sync?new Date(r.last_sync*1000).toLocaleString():'-'}</td><td>${r.drift_count||0}</td><td><button class="btn sm" onclick="goSync('${_esc(r.name)}')"><i class="fa-solid fa-rotate"></i></button> <button class="btn sm danger" onclick="goDel('${_esc(r.name)}')"><i class="fa-solid fa-trash"></i></button></td></tr>`).join('') : '<tr><td colspan="7" class="text-center text-muted" style="padding:14px">Repo yok</td></tr>';
-}
-async function goAddRepo() {
-  const body = {
-    name: document.getElementById('go-name').value.trim(),
-    url: document.getElementById('go-url').value.trim(),
-    branch: document.getElementById('go-branch').value.trim() || 'main',
-    auto_apply: document.getElementById('go-auto').checked,
-  };
-  if (!body.name || !body.url) { toast('Ad ve URL gerekli','error'); return; }
-  const d = await _api('/api/v2/gitops/repos','POST',body);
-  if (d) { toast('Repo eklendi','success'); loadGitOpsPage(); }
-}
-async function goSync(n) {
-  const d = await _api(`/api/v2/gitops/repos/${encodeURIComponent(n)}/sync`,'POST');
-  if (d) { toast('Sync başlatıldı','success'); loadGitOpsPage(); }
-}
-async function goDel(n) {
-  if (!await showConfirm(`${n} repo'su silinecek. Devam?`,'Repo Sil',true)) return;
-  const d = await _api(`/api/v2/gitops/repos/${encodeURIComponent(n)}`,'DELETE');
-  if (d) { toast('Silindi','success'); loadGitOpsPage(); }
-}
-
-/* ──── Firecracker microVMs ──── */
-async function loadFirecrackerPage() {
-  const d = await _api('/api/v3/firecracker/vms');
-  const arr = (d && d.vms) || [];
-  const tb = document.getElementById('fc-tbody');
-  if (tb) tb.innerHTML = arr.length ? arr.map(v => `<tr><td style="font-family:monospace;font-size:10px">${_esc(v.id||'-')}</td><td><b>${_esc(v.name||'-')}</b></td><td>${v.vcpus||1}</td><td>${v.memory_mb||0} MB</td><td>${_esc(v.state||'-')}</td><td style="font-family:monospace;font-size:10px">${_esc((v.api_socket||'').split('/').pop())}</td><td><button class="btn sm" onclick="fcStop('${_esc(v.id)}')"><i class="fa-solid fa-stop"></i></button></td></tr>`).join('') : '<tr><td colspan="7" class="text-center text-muted" style="padding:14px">microVM yok</td></tr>';
-}
-async function fcLaunch() {
-  const body = {
-    name: document.getElementById('fc-name').value.trim(),
-    kernel_path: document.getElementById('fc-kernel').value.trim(),
-    rootfs_path: document.getElementById('fc-rootfs').value.trim(),
-    vcpus: parseInt(document.getElementById('fc-vcpu').value || '1', 10),
-    memory_mb: parseInt(document.getElementById('fc-mem').value || '128', 10),
-  };
-  if (!body.name || !body.kernel_path || !body.rootfs_path) { toast('Ad / kernel / rootfs gerekli','error'); return; }
-  const d = await _api('/api/v3/firecracker/vms','POST',body);
-  if (d) { toast('microVM sıraya alındı','success'); loadFirecrackerPage(); }
-}
-async function fcStop(id) {
-  const d = await _api(`/api/v3/firecracker/vms/${id}/stop`,'POST');
-  if (d) { toast('Durduruldu','success'); loadFirecrackerPage(); }
-}
+/* KubeVirt / GitOps / Firecracker panes are served by the original
+   enterprise-tab implementations (loadKubevirtPage / loadGitopsPage /
+   loadFirecrackerPage). The v2.7.2 real backends are reachable at
+   /api/v2/kubevirt, /api/v2/gitops, /api/v3/firecracker. Duplicate
+   panes + loaders removed to avoid clashing element IDs. */
 
 /* ──── OAuth2 Presets ──── */
 let _opCurrentPreset = null;
@@ -37655,9 +37550,6 @@ async function telePreview() {
   if (typeof window === 'undefined') return;
   const map = {
     'ent-pane-csi': loadCsiPage,
-    'ent-pane-kubevirt': loadKubeVirtPage,
-    'ent-pane-gitops': loadGitOpsPage,
-    'ent-pane-firecracker': loadFirecrackerPage,
     'ent-pane-oauth2presets': loadOauth2PresetsPage,
     'ent-pane-auditretention': loadAuditRetentionPage,
     'ent-pane-sbom': loadSbomPage,
@@ -37915,11 +37807,8 @@ const _PAGE_TABS = {
     {key:'cloudburst', label:'Cloud Burst', src:'ent-pane-cloudburst'},
     {key:'baremetal', label:'Bare-Metal', src:'ent-pane-baremetal'},
     {key:'apidocs', label:'API Docs', src:'ent-pane-apidocs'},
-    // v2.7.2 — Cloud-Native
+    // v2.7.2 — Cloud-Native (kubevirt/gitops/firecracker already registered above)
     {key:'csi', label:'Kubernetes CSI', src:'ent-pane-csi'},
-    {key:'kubevirt', label:'KubeVirt Bridge', src:'ent-pane-kubevirt'},
-    {key:'gitops', label:'GitOps', src:'ent-pane-gitops'},
-    {key:'firecracker', label:'Firecracker', src:'ent-pane-firecracker'},
     {key:'oauth2presets', label:'OAuth2 Presets', src:'ent-pane-oauth2presets'},
     {key:'auditretention', label:'Audit Retention', src:'ent-pane-auditretention'},
     {key:'sbom', label:'SBOM', src:'ent-pane-sbom'},

--- a/oxware/frontend/templates/login.html
+++ b/oxware/frontend/templates/login.html
@@ -517,11 +517,11 @@
         <div class="brand-product">
           <strong>OXware</strong><sup>®</sup> Hypervisor<sup>™</sup>
         </div>
-        <div class="brand-edition">KVM / QEMU · v2.7.2</div>
+        <div class="brand-edition">KVM / QEMU · v2.8.0</div>
       </div>
     </div>
 
-    <div class="ver-footer">OXware Hypervisor v2.7.2</div>
+    <div class="ver-footer">OXware Hypervisor v2.8.0</div>
   </div>
 
   <script>


### PR DESCRIPTION
…sion bump

Backends (real, guarded on host tooling):
- csi_driver: qemu-img qcow2 provision/resize/delete, backend_ready report
- firecracker_runtime: real Popen launch + config, SIGTERM stop, status
- gitops_manager: git clone/pull manifest sync, token injected + scrubbed

Frontend (templates/index.html):
- Remove duplicate kubevirt/gitops/firecracker panes/loaders/registry/ dispatch; keep original enterprise-tab handlers (/api/kubevirt|gitops| firecracker). No dangling refs, no duplicate IDs.
- Wire csi-ready-badge to /api/v2/csi/info backend_ready

Versions: unify panel to 2.8.0 (app.py, login, index template, sbom)

Verified: py_compile OK, pytest 22 passed/17 skipped, node --check JS OK

<!-- Thank you for contributing to OXware! Please fill in the relevant
sections below and delete the rest. Empty PRs and "I'll fix it later"
descriptions are routinely closed without review. -->

## Summary

<!-- 1–2 sentences. What does this PR do? -->

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔒 Security fix (assign a SEC-NNN id; reference [`SECURITY.md`](../SECURITY.md))
- [ ] 📝 Documentation only
- [ ] 🌍 Translation / i18n
- [ ] ⚡ Performance
- [ ] 🧹 Refactor / cleanup

## Linked issue

Closes #
<!-- Or: References #123, partially implements #456 -->

## Checklist

- [ ] My code follows the style of this project (`make security` and `make test` pass locally)
- [ ] I have added an entry in `CHANGELOG.md` under the next unreleased version
- [ ] I have updated relevant docs (`README.md`, `oxware.top/docs/`)
- [ ] **i18n parity:** if I touched `oxware/frontend/templates/index.html`, I ran `make i18n` (or the pre-commit hook ran it for me)
- [ ] **Modularization:** new routes land in `oxware/backend/blueprints/`, not in `app.py` (see [`MODULARIZATION_PLAN.md`](../MODULARIZATION_PLAN.md))
- [ ] **Security:** if this PR touches auth, federation, runbook executor, plugin SDK, or any subprocess call, I have considered SSRF / path traversal / argv injection and used `security_utils.*` helpers where appropriate
- [ ] For security fixes: I have requested a SEC-NNN id and added the entry to `SECURITY.md`
- [ ] Tests added or updated; SEC-017..033 regression suite stays green

## How to verify

<!-- Step-by-step instructions so a reviewer can reproduce your test. -->

## Screenshots / output

<!-- Drop screenshots, terminal output, or curl examples here if relevant. -->

---

By submitting this PR, you agree to license your contribution under the [MIT License](../LICENSE).
